### PR TITLE
Testing proof-of-concept

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ pids
 *.seed
 
 node_modules
+
+# Ignore testing outputs, keep testing script
+tests/output*

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Vuepress is a boilerplate used to build smooth, responsive [WordPress](https://w
 1. [Building a Vuepress Site: Front-End](#building-a-vuepress-site-front-end)
     1. [Example Workflow](#example-workflow)
     1. [Common Tasks](#common-tasks)
+1. [Testing](#testing)
 1. [Recommended Reading](#recommended-reading)
 
 
@@ -277,6 +278,14 @@ Once you've set up the routing for a Vuepress site and understand its state func
     ```
 
     You must include either an `object` or a `src` parameter on a `responsive-image` element; all other values are optional.
+
+## Testing
+Vuepress comes with some commands to simplify testing your site.
+
+1. `npm i --only=dev` - Installs dev dependencies like [Puppeteer](https://github.com/GoogleChrome/puppeteer) and [Rimraf](https://www.npmjs.com/package/rimraf)
+1. Navigate to `tests/index.js` and fill in the desired base URL, then additional pages
+1. `npm run test` - Screenshots all of the pages defined in `tests/index.js`. Outputs to `tests/output-${ timestamp }/`.
+1. `npm run cleanup` - Removes all test output directories.
 
 ## Recommended Reading
 Not Vuepress-specific reading material, but rather good practices and articles.

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,15 @@
         }
       }
     },
+    "agent-base": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.1.1.tgz",
+      "integrity": "sha512-yWGUUmCZD/33IRjG2It94PzixT8lX+47Uq8fjmd0cgQWITCMrJuXFaVIMnGDmDnZGGKAGdwTx8UGeU8lMR2urA==",
+      "dev": true,
+      "requires": {
+        "es6-promisify": "5.0.0"
+      }
+    },
     "ajv": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
@@ -207,6 +216,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+    },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+      "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
@@ -1595,6 +1610,15 @@
         "clone": "1.0.2"
       }
     },
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
+      }
+    },
     "defined": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
@@ -1611,7 +1635,7 @@
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.1"
+        "rimraf": "2.6.2"
       }
     },
     "delayed-stream": {
@@ -1800,6 +1824,35 @@
         "is-arrayish": "0.2.1"
       }
     },
+    "es-abstract": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.9.0.tgz",
+      "integrity": "sha512-kk3IJoKo7A3pWJc0OV8yZ/VEX2oSUytfekrJiqoxBlKJMFAJVJVpGdHClCCTdv+Fn2zHfpDHHIelMFhZVfef3Q==",
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.1",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
+      },
+      "dependencies": {
+        "function-bind": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+        }
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "requires": {
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
+      }
+    },
     "es5-ext": {
       "version": "0.10.23",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
@@ -1830,6 +1883,21 @@
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
+      }
+    },
+    "es6-promise": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+      "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng==",
+      "dev": true
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "4.1.1"
       }
     },
     "es6-set": {
@@ -2199,6 +2267,44 @@
         }
       }
     },
+    "extract-zip": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.5.tgz",
+      "integrity": "sha1-maBnNbbqIOqbcF13ms/8yHz/BEA=",
+      "dev": true,
+      "requires": {
+        "concat-stream": "1.6.0",
+        "debug": "2.2.0",
+        "mkdirp": "0.5.0",
+        "yauzl": "2.4.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+          "dev": true
+        }
+      }
+    },
     "extsprintf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
@@ -2218,6 +2324,15 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
       "integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg="
+    },
+    "fd-slicer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "dev": true,
+      "requires": {
+        "pend": "1.2.0"
+      }
     },
     "figures": {
       "version": "1.7.0",
@@ -2310,6 +2425,11 @@
         "for-in": "1.0.2"
       }
     },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -2335,7 +2455,7 @@
         "graceful-fs": "4.1.11",
         "jsonfile": "2.4.0",
         "path-is-absolute": "1.0.1",
-        "rimraf": "2.6.1"
+        "rimraf": "2.6.2"
       }
     },
     "fs.realpath": {
@@ -3249,7 +3369,7 @@
         "graceful-fs": "4.1.11",
         "inherits": "2.0.3",
         "mkdirp": "0.5.1",
-        "rimraf": "2.6.1"
+        "rimraf": "2.6.2"
       }
     },
     "fstream-ignore": {
@@ -3526,6 +3646,16 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
       "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI="
     },
+    "https-proxy-agent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.1.0.tgz",
+      "integrity": "sha512-/DTVSUCbRc6AiyOV4DBRvPDpKKCJh4qQJNaCgypX0T41quD9hp/PB5iUyx/60XobuMPQa9ce1jNV9UOUq6PnTg==",
+      "dev": true,
+      "requires": {
+        "agent-base": "4.1.1",
+        "debug": "2.6.8"
+      }
+    },
     "icss-replace-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
@@ -3667,6 +3797,16 @@
         "builtin-modules": "1.1.1"
       }
     },
+    "is-callable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+    },
     "is-directory": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
@@ -3779,6 +3919,14 @@
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
     },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "requires": {
+        "has": "1.0.1"
+      }
+    },
     "is-resolvable": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
@@ -3794,6 +3942,11 @@
       "requires": {
         "html-comment-regex": "1.1.1"
       }
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -4047,11 +4200,6 @@
       "resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
       "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU="
     },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
-    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -4181,11 +4329,6 @@
         "minimist": "0.0.8"
       }
     },
-    "morlock": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/morlock/-/morlock-0.4.5.tgz",
-      "integrity": "sha1-VIMLvzdXGmZG2tfaxaa1kygGtPA="
-    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -4255,7 +4398,7 @@
         "npmlog": "4.1.2",
         "rc": "1.2.1",
         "request": "2.81.0",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "semver": "5.4.1",
         "tar": "2.2.1",
         "tar-pack": "3.4.0"
@@ -4351,6 +4494,11 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
+    "object-keys": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+    },
     "object.omit": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
@@ -4372,6 +4520,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+    },
+    "open": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/open/-/open-0.0.5.tgz",
+      "integrity": "sha1-QsPhjslUZra/DcQvOilFw/DK2Pw=",
+      "dev": true
     },
     "optimist": {
       "version": "0.3.7",
@@ -4539,6 +4693,12 @@
         "safe-buffer": "5.1.0",
         "sha.js": "2.4.8"
       }
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true
     },
     "performance-now": {
       "version": "0.2.0",
@@ -5188,6 +5348,12 @@
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
     },
+    "proxy-from-env": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
+      "dev": true
+    },
     "prr": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
@@ -5214,6 +5380,30 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "puppeteer": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-0.11.0.tgz",
+      "integrity": "sha512-/o8uY6VChG74B1HYBZkLDU6aIekWeOd85wez9YxB9SNbDnFNsUddv2F4xWuhwvQ4ab84vb+1VX4fxs2kBz3u8g==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.8",
+        "extract-zip": "1.6.5",
+        "https-proxy-agent": "2.1.0",
+        "mime": "1.3.6",
+        "progress": "2.0.0",
+        "proxy-from-env": "1.0.0",
+        "rimraf": "2.6.2",
+        "ws": "3.2.0"
+      },
+      "dependencies": {
+        "progress": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+          "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+          "dev": true
+        }
+      }
     },
     "q": {
       "version": "1.5.0",
@@ -5589,9 +5779,9 @@
       }
     },
     "rimraf": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
         "glob": "7.1.2"
       }
@@ -5831,6 +6021,16 @@
         "strip-ansi": "3.0.1"
       }
     },
+    "string.prototype.padstart": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.padstart/-/string.prototype.padstart-3.0.0.tgz",
+      "integrity": "sha1-W8+tOfRkm7LQMSkuGbzwtRDUskI=",
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.9.0",
+        "function-bind": "1.1.0"
+      }
+    },
     "string_decoder": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
@@ -5995,7 +6195,7 @@
         "fstream-ignore": "1.0.5",
         "once": "1.4.0",
         "readable-stream": "2.3.0",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "tar": "2.2.1",
         "uid-number": "0.0.6"
       }
@@ -6113,6 +6313,12 @@
       "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
       "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
       "optional": true
+    },
+    "ultron": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.0.tgz",
+      "integrity": "sha1-sHoualQagV/Go0zNRTO67DB8qGQ=",
+      "dev": true
     },
     "underscore": {
       "version": "1.8.3",
@@ -6498,6 +6704,17 @@
         "mkdirp": "0.5.1"
       }
     },
+    "ws": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-3.2.0.tgz",
+      "integrity": "sha512-hTS3mkXm/j85jTQOIcwVz3yK3up9xHgPtgEhDBOH3G18LDOZmSAG1omJeXejLKJakx+okv8vS1sopgs7rw0kVw==",
+      "dev": true,
+      "requires": {
+        "async-limiter": "1.0.0",
+        "safe-buffer": "5.1.0",
+        "ultron": "1.1.0"
+      }
+    },
     "xmldom": {
       "version": "0.1.27",
       "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
@@ -6617,6 +6834,15 @@
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
         }
+      }
+    },
+    "yauzl": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "dev": true,
+      "requires": {
+        "fd-slicer": "1.0.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "dev": "NODE_PATH=. webpack --progress --colors --watch",
-    "build": "NODE_PATH=. NODE_ENV=production webpack --progress --hide-modules"
+    "build": "NODE_PATH=. NODE_ENV=production webpack --progress --hide-modules",
+    "test": "NODE_PATH=. node tests",
+    "cleanup": "NODE_PATH=. node tests/remove"
   },
   "author": "Funkhaus",
   "license": "ISC",
@@ -38,6 +40,7 @@
     "postcss-loader": "^1.3.3",
     "postcss-url": "^5.1.2",
     "sass-loader": "^6.0.6",
+    "string.prototype.padstart": "^3.0.0",
     "style-loader": "^0.13.1",
     "svg-inline-loader": "^0.7.1",
     "url-loader": "^0.5.9",
@@ -49,5 +52,10 @@
     "vuex": "^2.3.1",
     "webpack": "^2.2.1",
     "whatwg-fetch": "^2.0.3"
+  },
+  "devDependencies": {
+    "open": "0.0.5",
+    "puppeteer": "^0.11.0",
+    "rimraf": "^2.6.2"
   }
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,0 +1,45 @@
+/* eslint no-console: "off" */
+const open = require('open')
+const fs = require('fs')
+const padStart = require('string.prototype.padstart')
+
+// YOUR TEST URL HERE
+const baseUrl = 'http://vuepress.dev'
+
+// YOUR TEST PAGES HERE
+const screenshotPaths = [
+    'example-page',
+    'example-page/detail'
+]
+
+console.log(`Testing '${ baseUrl }'...`)
+
+// create output folder with current timestamp
+const outputDir = 'tests/output-' + Date.now()
+fs.mkdirSync(outputDir)
+
+const puppeteer = require('puppeteer');
+
+(async () => {
+
+    const browser = await puppeteer.launch()
+    const page = await browser.newPage()
+
+    await page.goto(baseUrl)
+    await page.screenshot({ path: outputDir + '/01 - home.png' })
+
+    let index = 2
+
+    for( let path of screenshotPaths ){
+        await page.goto(`${ baseUrl }/${ path }`)
+        await page.screenshot({ path: outputDir + `/${ padStart(index++, 2, '0') } - ${ path.replace('/', ' - ') }.png` })
+    }
+
+    await browser.close()
+
+    console.log('Tests complete! Opening results...')
+
+    open(`${ outputDir }/01 - home.png`)
+    open(outputDir)
+
+})()

--- a/tests/remove.js
+++ b/tests/remove.js
@@ -1,0 +1,5 @@
+/* eslint no-console: 0 */
+
+const rimraf = require('rimraf')
+rimraf.sync('tests/output-*')
+console.log('Removed test output directories!')


### PR DESCRIPTION
Added sample testing capabilities:

* `npm run test` - screenshots each path in the `tests/index.js` `screenshotPaths` array
* `npm run cleanup` - removes test output directories